### PR TITLE
Obertauern update

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -3,6 +3,8 @@ main:
     url: /
   - title: "About"
     url: /about/
+  - title: "Courses"
+    url: /courses/
 
 banz_2025_sidebar:
   - title: "Banz 2025"

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -3,5 +3,13 @@ main:
     url: /
   - title: "About"
     url: /about/
+
+banz_2025_sidebar:
   - title: "Banz 2025"
-    url: /banz-2025/
+    children:
+      - title: "Overview"
+        url: /banz-2025/
+      - title: "Technical Topics"
+        url: /banz-2025/technical/
+      - title: "Societal Topics"
+        url: /banz-2025/societal/

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -8,16 +8,11 @@ Artificial intelligence and machine learning are reshaping how we live, work, an
 
 Our project exists to bridge this gap. We bring **technical foundations** and **societal perspectives** together in one classroom, creating space for students from diverse disciplines to learn, question, and collaborate.
 
-## Teaching Philosophy
+## Philosophy
 
-Our team believes that AI and machine learning education should not remain the domain of specialists alone. Our mission is to deliver an approach that is:
+Our team believes that AI and machine learning education should not remain the domain of specialists alone. We deliver an approach that is **accessible** to all, **hands-on** by design, and deeply **critical** of the impact these technologies have on our world.
 
-- **Accessible** — tailored to students and professionals from diverse disciplines
-- **Hands-on** — focused on interactive coding and practical data analysis
-- **Critical** — addressing fairness, transparency, regulation, and ethical questions
-- **Interdisciplinary** — creating dialogue between natural sciences, social sciences, and the humanities
-
-Our courses are designed to be both **practically useful** and **thought-provoking**, equipping participants with skills and perspectives they can carry into their own fields.
+Our courses are designed to be both **practically useful** and **thought-provoking**, equipping participants with skills and perspectives they can carry into their own fields. For a deeper look at our specific curriculum and guiding principles, see our [Courses](/courses/).
 
 ## Who We Are
 
@@ -85,19 +80,11 @@ Our courses are designed to be both **practically useful** and **thought-provoki
   We look forward to learning and exploring with you!
 </div>
 
-## Where We’ve Taught
+## Experience
 
 Since 2019, our courses have been part of summer academies and workshops across Europe, often in collaboration with the *Studienstiftung des Deutschen Volkes* (German National Academic Foundation) and other academic partners.
 
-- 🇬🇧 **2019, Cambridge, UK** — St. John’s College, Cambridge, with participants from Cambridge University.
-
-- 🇩🇪 **2021, Koppelsberg, Germany** — Interdisciplinary summer academy with participants from across Germany.
-
-- 🇸🇮 **2024, Ljubljana, Slovenia** — Joint program with students from the *Max Weber Program, Elite Network of Bavaria*.
-
-- 🇩🇪 **2025, Banz Castle, Germany** — Summer academy with participants from the *College of Europe*.
-
-Each of these programs brought together students from diverse disciplines — philosophy, law, economics, biology, physics, and more — creating a truly interdisciplinary dialogue on AI and society.
+Recent locations include **Cambridge**, **Ljubljana**, and **Banz Abbey**. You can find a full list of our past editions and specific course materials in our [Courses](/courses/) section.
 
 ## Open Resources
 

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -84,7 +84,8 @@ Our courses are designed to be both **practically useful** and **thought-provoki
 
 Since 2019, our courses have been part of summer academies and workshops across Europe, often in collaboration with the *Studienstiftung des Deutschen Volkes* (German National Academic Foundation) and other academic partners.
 
-Recent locations include **Cambridge**, **Ljubljana**, and **Banz Abbey**. You can find a full list of our past editions and specific course materials in our [Courses](/courses/) section.
+Recent locations include **Cambridge, UK**, **Ljubljana, Slovenia**, and **Banz Abbey, Germany**.
+You can find a full list of our past editions and specific course materials in our [Courses](/courses/) section.
 
 ## Open Resources
 

--- a/_pages/banz-2025/overview.md
+++ b/_pages/banz-2025/overview.md
@@ -2,6 +2,8 @@
 title: "Banz 2025 – Machine Learning Workshop"
 description: "Overview of the Banz 2025 workshop — a modular, hands-on introduction to machine learning and its societal impact for interdisciplinary audiences."
 permalink: /banz-2025/
+sidebar:
+  nav: "banz_2025_sidebar"
 ---
 
 Welcome to the **Banz 2025 Machine Learning Workshop**, part of the summer school program of the German Academic Scholarship Foundation. This modular, hands-on and discussion-driven workshop introduces core concepts of machine learning (ML), practical tools for data analysis, and the societal impact of AI and ML. It is designed for participants from diverse academic backgrounds.

--- a/_pages/banz-2025/societal.md
+++ b/_pages/banz-2025/societal.md
@@ -2,6 +2,8 @@
 title: "Societal Sessions at Banz 2025"
 description: "Discussion-based sessions from the Banz 2025 Machine Learning workshop, covering algorithmic bias, AI regulation, misinformation, and ethics."
 permalink: /banz-2025/societal/
+sidebar:
+  nav: "banz_2025_sidebar"
 ---
 
 This page outlines the themes and discussion questions for the **Societal Sessions at Banz 2025**, part of the Machine Learning workshop of the German Academic Scholarship Foundation. These sessions explore the social and ethical dimensions of AI and machine learning, including topics such as algorithmic bias, regulation, misinformation, and broader questions of responsibility. Each theme is designed for a 60-minute participant-led discussion with guiding questions and interdisciplinary perspectives.

--- a/_pages/banz-2025/technical.md
+++ b/_pages/banz-2025/technical.md
@@ -2,6 +2,8 @@
 title: "Technical Sessions at Banz 2025"
 description: "Technical sessions from the Banz 2025 Machine Learning workshop — collaborative modules on classification, regression, decision trees, and neural networks."
 permalink: /banz-2025/technical/
+sidebar:
+  nav: "banz_2025_sidebar"
 ---
 
 This page outlines the structure and content of the **Technical Sessions at Banz 2025**, part of the Machine Learning workshop of the German Academic Scholarship Foundation. These sessions cover major areas of machine learning, including classification, regression, decision trees, and neural networks. Each module is designed as a collaborative, discussion-based learning experience for an interdisciplinary audience.

--- a/_pages/courses.md
+++ b/_pages/courses.md
@@ -29,19 +29,19 @@ We adapt our courses to different academic settings and goals. Depending on the 
 
 ## 🏔️ Current & Past Editions
 
-- **[Obertauern 2026](/obertauern-2026/)**:
-Our upcoming flagship summer school. We explore the paradigm shift from classical machine learning to generative models and autonomous agents. Topics include Transformers, RAG, and the societal implications of increasingly autonomous systems.
+- 🇦🇹 **[Obertauern 2026, Austria](/obertauern-2026/)**:
+Our upcoming flagship summer school in the Austrian Alps. We explore the paradigm shift from classical machine learning to generative models and autonomous agents. Topics include Transformers, RAG, and the societal implications of increasingly autonomous systems.
 
-- **[Banz Abbey 2025](/banz-2025/)**:
+- 🇩🇪 **[Banz Abbey 2025, Germany](/banz-2025/)**:
 Summer academy with participants from the *College of Europe*.
 
-- **Ljubljana 2024**:
+- 🇸🇮 **Ljubljana 2024, Slovenia**:
 Joint program with students from the *Max Weber Program, Elite Network of Bavaria*.
 
-- **Koppelsberg 2021**:
+- 🇩🇪 **Koppelsberg 2021, Germany**:
 Interdisciplinary summer academy with participants from across Germany.
 
-- **Cambridge 2019**:
+- 🇬🇧 **Cambridge 2019, UK**:
 St. John’s College, Cambridge, with participants from Cambridge University.
 
 

--- a/_pages/courses.md
+++ b/_pages/courses.md
@@ -1,0 +1,57 @@
+---
+title: "Courses"
+subtitle: "Curriculum, Formats, and Editions"
+description: "Explore our interdisciplinary machine learning curriculum, teaching approach, and past/upcoming course editions."
+permalink: /courses/
+author_profile: true
+---
+
+We design and teach **interdisciplinary courses on machine learning (ML) and artificial intelligence (AI)**. Our programs combine **technical insight** with **societal reflection**, encouraging participants to explore both *how these systems work* and *what they mean for our world*.
+
+
+## 🧭 Our Approach
+
+Our teaching is built on three guiding principles that define every course we lead:
+
+- **Accessibility** — We make machine learning approachable for participants from diverse academic backgrounds. Concepts are introduced with clarity and intuition, without assuming prior technical knowledge.
+- **Active Learning** — Instead of passive lectures, we focus on interaction, experimentation, and discussion. Participants work with real examples and bring in perspectives from their own fields.
+- **Societal Perspective** — Technical ideas are always connected to broader questions. We explore the ethical, legal, and societal implications of AI alongside its methods.
+
+
+## 🛠️ Flexible Formats
+
+We adapt our courses to different academic settings and goals. Depending on the context, this may mean:
+
+- **Short Workshops** — Compact sessions providing a focused introduction.
+- **Multi-day Academies** — Intensive programs combining technical modules, practical exercises, and interdisciplinary discussions.
+- **Guest Lectures** — Thematic modules enriching existing university or scholarship curricula.
+
+
+## 🏔️ Current & Past Editions
+
+- **[Obertauern 2026](/obertauern-2026/)**:
+Our upcoming flagship summer school. We explore the paradigm shift from classical machine learning to generative models and autonomous agents. Topics include Transformers, RAG, and the societal implications of increasingly autonomous systems.
+
+- **[Banz Abbey 2025](/banz-2025/)**:
+Summer academy with participants from the *College of Europe*.
+
+- **Ljubljana 2024**:
+Joint program with students from the *Max Weber Program, Elite Network of Bavaria*.
+
+- **Koppelsberg 2021**:
+Interdisciplinary summer academy with participants from across Germany.
+
+- **Cambridge 2019**:
+St. John’s College, Cambridge, with participants from Cambridge University.
+
+
+## 📚 Themes We Explore
+
+The exact content of a course depends on the audience and duration. Common themes include:
+
+- **Core ML Concepts** — what machine learning is, how it differs from traditional programming, and how models learn from data.
+- **Methods & Techniques** — regression, classification, tree-based models, neural networks, evaluation strategies.
+- **Practical Data Work** — using Python and modern libraries to explore datasets, train models, and visualize results.
+- **Societal Impact** — algorithmic bias and fairness, global regulation, AI in healthcare, misinformation, and the future of work.
+
+Interested in hosting a workshop or learning more about our curriculum? [Get in touch](/about/).

--- a/_pages/index.md
+++ b/_pages/index.md
@@ -22,19 +22,19 @@ Learn more about [our curriculum and past editions](/courses/).
 
 ---
 
-## Current Focus: Obertauern 2026
+## Current Focus: Obertauern 2026 (Austria)
 
-Following our successful school at Banz Abbey in 2025, we are now preparing for the next iteration in **Obertauern**. While this new course remains true to our core mission of bridging foundational ML and societal impact, we will also incorporate recent developments in generative AI and autonomous systems.
+Following our successful school at Banz Abbey in 2025, we are now preparing for the next iteration in **Obertauern, Austria**. While this new course remains true to our core mission of bridging foundational ML and societal impact, we will also incorporate recent developments in generative AI and autonomous systems.
 
-> 🏔️ **Obertauern 2026: The Next School**
->
-> Our upcoming summer school will explore the shift from classical machine learning to recent breakthroughs like LLMs and Agents.
->
-> **Sign-up deadline: 1 May 2026**
->
-> [**Obertauern 2026 Course Website »**](/obertauern-2026/)
->
-> [**Official Studienstiftung announcement »**](https://www.studienstiftung.de/kalender/programmlinien/detail/26012404)
+<div class="notice--info">
+  <p><strong>🏔️ Obertauern 2026: The Next School</strong></p>
+  <p>Our upcoming summer school in the Austrian Alps will explore the shift from classical machine learning to recent breakthroughs like LLMs and Agents.</p>
+  <p><strong>Sign-up deadline: 1 May 2026</strong></p>
+  <p>
+    <a href="/obertauern-2026/"><strong><i class="fas fa-arrow-right"></i> Obertauern 2026 Course Website</strong></a><br>
+    <a href="https://www.studienstiftung.de/kalender/programmlinien/detail/26012404" target="_blank" rel="noopener noreferrer"><strong><i class="fas fa-external-link-alt"></i> Official Studienstiftung announcement</strong></a>
+  </p>
+</div>
 
 ---
 

--- a/_pages/index.md
+++ b/_pages/index.md
@@ -20,11 +20,10 @@ We help participants build a clear understanding of core machine learning ideas,
 
 Learn more about [our curriculum and past editions](/courses/).
 
----
 
 ## Current Focus: Obertauern 2026 (Austria)
 
-Following our successful school at Banz Abbey in 2025, we are now preparing for the next iteration in **Obertauern, Austria**. While this new course remains true to our core mission of bridging foundational ML and societal impact, we will also incorporate recent developments in generative AI and autonomous systems.
+Following our successful school at Banz Abbey, Germany in 2025, we are now preparing for the next iteration in **Obertauern, Austria**. While this new course remains true to our core mission of bridging foundational ML and societal impact, we will also incorporate recent developments in generative AI and autonomous systems.
 
 <div class="notice--info">
   <p><strong>🏔️ Obertauern 2026: The Next School</strong></p>

--- a/_pages/index.md
+++ b/_pages/index.md
@@ -14,27 +14,28 @@ Our formats are interactive, adaptable, and discussion-driven — ranging from s
   <img src="/assets/img/logo.jpg" alt="Bridging AI and Society Banner" width="500">
 </p>
 
-## What We Do
+## Our Mission
 
-Our courses help participants:
-- Build a clear understanding of core machine learning ideas
-- Experiment hands-on with data and simple models
-- Reflect on the societal, ethical, and regulatory implications of AI
-- Connect technical knowledge with perspectives from their own disciplines
+We help participants build a clear understanding of core machine learning ideas, experiment hands-on with real-world data, and reflect on the societal, ethical, and regulatory implications of AI. By connecting technical knowledge with perspectives from diverse disciplines, we provide the mental models and practical experience needed to understand the current AI landscape.
 
-We adapt each program to its audience — from compact university seminars to intensive summer schools.
-
-## Experience and Partners
-
-Our teaching has been part of programs run by the **Studienstiftung des Deutschen Volkes** (German National Academic Foundation) and in collaboration with other academic institutions.
-
-Courses have taken place in settings such as **St. John’s College, Cambridge (UK)**, **Ljubljana (Slovenia)**, and **Banz Abbey (Germany)**, bringing together participants from diverse academic backgrounds.
+Learn more about [our curriculum and past editions](/courses/).
 
 ---
 
-For more about us — including contact details — see the [About page](/about/).
+## Current Focus: Obertauern 2026
+
+Following our successful school at Banz Abbey in 2025, we are now preparing for the next iteration in **Obertauern**. While this new course remains true to our core mission of bridging foundational ML and societal impact, we will also incorporate recent developments in generative AI and autonomous systems.
+
+> 🏔️ **Obertauern 2026: The Next School**
+>
+> Our upcoming summer school will explore the shift from classical machine learning to recent breakthroughs like LLMs and Agents.
+>
+> **Sign-up deadline: 1 May 2026**
+>
+> [**Obertauern 2026 Course Website »**](/obertauern-2026/)
+>
+> [**Official Studienstiftung announcement »**](https://www.studienstiftung.de/kalender/programmlinien/detail/26012404)
 
 ---
 
-> 💡 Curious about what the course looks like in practice?
-> Visit our latest iteration: [**Banz 2025 Course Website »**](/banz-2025/)
+For more about us — including team bios and philosophy — see the [About page](/about/).

--- a/_pages/obertauern-2026/overview.md
+++ b/_pages/obertauern-2026/overview.md
@@ -1,10 +1,10 @@
 ---
-title: "Obertauern 2026 – Machine Learning Workshop"
-description: "Information about the upcoming Obertauern 2026 summer school on machine learning and society."
+title: "Obertauern 2026 – Machine Learning Workshop (Austria)"
+description: "Information about the upcoming Obertauern 2026 summer school on machine learning and society in Austria."
 permalink: /obertauern-2026/
 ---
 
-Welcome to the **Obertauern 2026 Machine Learning Workshop**, the upcoming iteration of our interdisciplinary course program.
+Welcome to the **Obertauern 2026 Machine Learning Workshop**, the upcoming iteration of our interdisciplinary course program. The school will take place in the mountains of **Obertauern, Austria**.
 
 For this edition, we are developing a curriculum that bridges the most recent technical breakthroughs with critical societal reflection. While the final program is still being finalized, participants can expect a modular course structure covering three main pillars:
 
@@ -24,9 +24,9 @@ We will dedicate significant time to discussing the consequences of these techno
 <div style="background-color: #f2f3f3; padding: 1.5rem; border-radius: 4px; border-left: 5px solid #336699; margin: 2rem 0;">
   <p style="margin-top: 0;">The course is part of the summer academy program of the <strong>Studienstiftung des Deutschen Volkes</strong>.</p>
   <p style="font-size: 1.2rem; font-weight: bold;">Sign-up deadline: 1 May 2026</p>
-  <p><a href="https://www.studienstiftung.de/kalender/programmlinien/detail/26012404" class="btn btn--primary btn--large">Official Announcement & Registration »</a></p>
+  <p><a href="https://www.studienstiftung.de/kalender/programmlinien/detail/26012404" target="_blank" rel="noopener noreferrer" class="btn btn--primary btn--large"><i class="fas fa-external-link-alt"></i> Official Announcement & Registration</a></p>
 </div>
 
-We look forward to seeing you in Obertauern!
+We look forward to seeing you in Austria!
 
-[⬅ Back to Courses](/courses/)
+[<i class="fas fa-arrow-left"></i> Back to Courses](/courses/)

--- a/_pages/obertauern-2026/overview.md
+++ b/_pages/obertauern-2026/overview.md
@@ -1,0 +1,32 @@
+---
+title: "Obertauern 2026 – Machine Learning Workshop"
+description: "Information about the upcoming Obertauern 2026 summer school on machine learning and society."
+permalink: /obertauern-2026/
+---
+
+Welcome to the **Obertauern 2026 Machine Learning Workshop**, the upcoming iteration of our interdisciplinary course program.
+
+For this edition, we are developing a curriculum that bridges the most recent technical breakthroughs with critical societal reflection. While the final program is still being finalized, participants can expect a modular course structure covering three main pillars:
+
+### 🧠 Modern AI & Machine Learning Foundations
+We will explore the paradigm shift from classical machine learning to generative models. The curriculum will provide the technical intuition needed to understand modern systems, including large language models and autonomous agents, without requiring a deep mathematical background.
+
+### 💻 Hands-on Exploration
+Practical experience is at the heart of our workshop. Participants will work with real tools and models directly in the browser. We will introduce Python as a tool for data science and explore how AI-assisted development (or "vibe coding") is changing the way we interact with technology.
+
+### 🌍 Societal, Ethical & Legal Reflection
+We will dedicate significant time to discussing the consequences of these technologies. Topics will include the evolving regulatory landscape (such as the EU AI Act), the impact of AI on the information ecosystem, and the future of work and creativity in an automated world.
+
+---
+
+### 📅 Registration Information
+
+<div style="background-color: #f2f3f3; padding: 1.5rem; border-radius: 4px; border-left: 5px solid #336699; margin: 2rem 0;">
+  <p style="margin-top: 0;">The course is part of the summer academy program of the <strong>Studienstiftung des Deutschen Volkes</strong>.</p>
+  <p style="font-size: 1.2rem; font-weight: bold;">Sign-up deadline: 1 May 2026</p>
+  <p><a href="https://www.studienstiftung.de/kalender/programmlinien/detail/26012404" class="btn btn--primary btn--large">Official Announcement & Registration »</a></p>
+</div>
+
+We look forward to seeing you in Obertauern!
+
+[⬅ Back to Courses](/courses/)


### PR DESCRIPTION

Prepare the site for the 2026 course cycle:

*   **Centralized "Courses" Hub**: Replaced individual program pages with a unified **[/courses/](/courses/)** section for curriculum, formats, and historical editions.
*   **Obertauern 2026**: Added dedicated workshop pages and prominent registration highlights (including the **1 May deadline**).
*   **Banz 2025 Navigation**: Introduced sidebar navigation for the Banz modules to improve deep-linking and accessibility.
*   **Content Refining**: Streamlined the **Home** and **About** pages to eliminate redundancy and focus on mission/team bios.
